### PR TITLE
Improve mobile experience

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,14 +2,16 @@
 <html lang="de">
 <head>
   <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
+  <meta name="apple-mobile-web-app-capable" content="yes" />
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
   <title>Endless Jump</title>
   <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
   <style>
     html, body {
       margin: 0;
       padding: 0;
-      height: 100vh;
+      height: 100dvh;
       background: radial-gradient(#0f0f0f, #000000);
       font-family: 'Press Start 2P', monospace;
       display: flex;
@@ -17,6 +19,10 @@
       align-items: center;
       overflow: hidden;
       color: #00ffcc;
+      -webkit-user-select: none;
+      user-select: none;
+      -webkit-tap-highlight-color: transparent;
+      touch-action: none;
     }
     #wrapper {
       background: #1c1c1c;
@@ -26,13 +32,16 @@
       align-items: center;
       border: 4px solid #000;
       box-sizing: border-box;
+      width: 100%;
+      height: 100%;
     }
     canvas {
       image-rendering: pixelated;
       max-width: 100vw;
-      max-height: 100vh;
+      max-height: 100dvh;
       width: 100%;
       height: auto;
+      touch-action: none;
     }
     #menu, #options, #controls, #gameover {
       position: absolute;
@@ -112,6 +121,27 @@
       pointer-events: none;
       text-shadow: 0 0 4px #ff0033;
     }
+    #rotateMsg {
+      display: none;
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      background: rgba(10, 10, 10, 0.95);
+      padding: 20px;
+      border: 4px double #00ffcc;
+      color: #00ffcc;
+      font-family: 'Press Start 2P', monospace;
+      text-align: center;
+      z-index: 20;
+    }
+
+    @media screen and (orientation: portrait) and (max-width: 900px) {
+      #rotateMsg { display: block; }
+      #wrapper, #menu, #options, #controls, #gameover, #score, #spruch {
+        display: none !important;
+      }
+    }
     @keyframes fadeIn {
       from { opacity: 0; transform: translate(-50%, -60%); }
       to   { opacity: 1; transform: translate(-50%, -50%); }
@@ -142,6 +172,7 @@
   <div id="score">Score: 0</div>
   <div id="spruch"></div>
   <div id="wrapper"><canvas id="game" width="1024" height="576"></canvas></div>
+  <div id="rotateMsg">🔄 Bitte Gerät drehen</div>
   <audio id="bgmusic" src="bgmusic.mp3" loop></audio>
   <audio id="darkmusic" src="darktheme.mp3" loop></audio>
   <audio id="gameovermusic" src="gameover.mp3" loop></audio>
@@ -294,7 +325,8 @@ document.addEventListener("keydown", e => {
   }
 });
 
-canvas.addEventListener("touchstart", () => {
+canvas.addEventListener("touchstart", e => {
+  e.preventDefault();
   if (gameReady) {
     startGame(true);
     gameReady = false;
@@ -303,6 +335,14 @@ canvas.addEventListener("touchstart", () => {
     player.onGround = false;
   }
 });
+
+function checkOrientation() {
+  if (window.matchMedia("(orientation: portrait)").matches) {
+    isGameRunning = false;
+  }
+}
+window.addEventListener("orientationchange", checkOrientation);
+checkOrientation();
 
 let lastTime = 0;
 function gameLoop(timestamp) {


### PR DESCRIPTION
## Summary
- support iPhone fullscreen and safe-area with `viewport-fit=cover`
- prevent text selection and zoom on touch devices
- ensure canvas fills the screen on mobile
- show an overlay requesting rotation when a phone is held vertically
- pause the game when portrait mode is detected

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6880542d9d38832a8be4ad4594ab82a9