### PR TITLE
Enable space restart on game over

### DIFF
--- a/index.html
+++ b/index.html
@@ -352,7 +352,7 @@ function startGame(withJump = false) {
 
 document.addEventListener("keydown", e => {
   if (e.code === "Space") {
-    if (!isGameRunning && wasInGameOverScreen) {
+    if (!isGameRunning && (wasInGameOverScreen || gameover.style.display === "block")) {
       wasInGameOverScreen = false;
       prepareGame();
       return;


### PR DESCRIPTION
## Summary
- allow restarting the game with the space key while the game over screen is visible

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68825b39c2b8832abe02339c173e0254