### PR TITLE
Enable space restart from first game over

### DIFF
--- a/index.html
+++ b/index.html
@@ -174,7 +174,6 @@ let platforms = [], gameReady = false, isGameRunning = false;
 const maxJumpHeight = Math.pow(Math.abs(jumpForce), 2) / (2 * gravity);
 let darkMusicStarted = false;
 let highscore = parseInt(localStorage.getItem("highscore") || "0");
-let wasInGameOverScreen = false;
 
 function fitScreen() {
   canvas.width = window.innerWidth;
@@ -298,7 +297,6 @@ function prepareGame() {
   fitScreen();
   [gameoverMusic, darkMusic, music].forEach(a => { a.pause(); a.currentTime = 0; });
   darkMusicStarted = false;
-  wasInGameOverScreen = false;
   [menu, options, controls, gameover, spruchBox].forEach(el => el.style.display = "none");
   scrollX = 0; speed = 3; speedTimer = 0; platforms = []; score = 0;
   const baseY = canvas.height - 80;
@@ -352,9 +350,11 @@ function startGame(withJump = false) {
 
 document.addEventListener("keydown", e => {
   if (e.code === "Space") {
-    if (!isGameRunning && wasInGameOverScreen) {
-      wasInGameOverScreen = false;
+    // Restart immediately if the game over overlay is visible
+    if (!isGameRunning && gameover.style.display === "block") {
       prepareGame();
+      startGame(true);
+      gameReady = false;
       return;
     }
     if (gameReady) {
@@ -441,7 +441,6 @@ function update(delta) {
 
   if (player.y > canvas.height) {
     isGameRunning = false;
-    wasInGameOverScreen = true;
     if (score > highscore) {
       highscore = score;
       localStorage.setItem("highscore", highscore);


### PR DESCRIPTION
## Summary
- remove leftover flag that blocked restarting with space
- restart immediately whenever the Game Over overlay is visible

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68825b39c2b8832abe02339c173e0254