### PR TITLE
Add death mode variant

### DIFF
--- a/deathmode.html
+++ b/deathmode.html
@@ -1,0 +1,592 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
+  <meta name="apple-mobile-web-app-capable" content="yes" />
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+  <title>Endless Jump</title>
+  <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
+  <style>
+    html, body {
+      margin: 0;
+      padding: 0;
+      height: 100dvh;
+      background: radial-gradient(#0f0f0f, #000000);
+      font-family: 'Press Start 2P', monospace;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      overflow: hidden;
+      color: #00ffcc;
+      -webkit-user-select: none;
+      user-select: none;
+      -webkit-tap-highlight-color: transparent;
+      touch-action: none;
+    }
+    #wrapper {
+      background: #1c1c1c;
+      padding: 8px;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      border: 4px solid #000;
+      box-sizing: border-box;
+      width: 100%;
+      height: 100%;
+    }
+    canvas {
+      image-rendering: pixelated;
+      width: 100vw;
+      height: 100dvh;
+      touch-action: none;
+    }
+    #menu, #options, #controls, #gameover {
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      background: rgba(10, 10, 10, 0.95);
+      padding: 60px 30px 30px 30px;
+      border: 4px double #00ffcc;
+      color: #00ffcc;
+      font-family: 'Press Start 2P', monospace;
+      text-align: center;
+      display: none;
+      z-index: 10;
+      box-shadow: 0 0 35px #00ffee;
+      animation: fadeIn 0.5s ease-in-out;
+    }
+    #gameover {
+      border: 4px double #ff0033;
+      color: #ff0033;
+      box-shadow: 0 0 35px #ff0033;
+      padding-top: 40px;
+    }
+    #menu h1, #gameover h1 {
+      font-size: 22px;
+      margin: 0 0 20px 0;
+      color: #fff;
+      text-shadow: 0 0 5px #00ffee, 0 0 10px #00ffee;
+    }
+    button {
+      margin: 10px;
+      padding: 14px 28px;
+      font-size: 14px;
+      font-family: 'Press Start 2P', monospace;
+      background: #000;
+      border: 2px solid #00ffcc;
+      color: #00ffcc;
+      cursor: pointer;
+      transition: all 0.2s ease;
+      text-shadow: 0 0 3px #00ffee;
+    }
+    button:hover {
+      background: #00ffee;
+      color: #000;
+      text-shadow: none;
+    }
+    #gameover button {
+      border: 2px solid #ff0033;
+      color: #ff0033;
+      text-shadow: 0 0 3px #ff0033;
+    }
+    #gameover button:hover {
+      background: #ff0033;
+      color: #000;
+    }
+    #spruch {
+      position: absolute;
+      right: 20px;
+      bottom: 20px;
+      transform: rotate(-6deg);
+      color: #fff;
+      font-size: 14px;
+      font-family: 'Press Start 2P', monospace;
+      max-width: 220px;
+      text-align: right;
+      z-index: 9;
+      display: none;
+      pointer-events: none;
+      text-shadow: 0 0 4px #ff0033;
+    }
+    #rotateMsg {
+      display: none;
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      background: rgba(10, 10, 10, 0.95);
+      padding: 20px;
+      border: 4px double #00ffcc;
+      color: #00ffcc;
+      font-family: 'Press Start 2P', monospace;
+      text-align: center;
+      z-index: 20;
+    }
+
+    @media screen and (orientation: portrait) and (max-width: 900px) {
+      #rotateMsg { display: block; }
+      #wrapper, #menu, #options, #controls, #gameover, #spruch {
+        display: none !important;
+      }
+    }
+    @keyframes fadeIn {
+      from { opacity: 0; transform: translate(-50%, -60%); }
+      to   { opacity: 1; transform: translate(-50%, -50%); }
+    }
+  </style>
+</head>
+<body>
+  <div id="menu">
+    <h1>🧟 ENDLESS JUMP</h1>
+    <button onclick="prepareGame()">▶ SPIEL STARTEN</button><br>
+    <button id="deathModeBtn" onclick="toggleDeathMode()">DEATH MODE: AUS</button><br>
+    <button onclick="showControls()">🕹️ STEUERUNG</button><br>
+    <button onclick="showOptions()">⚙️ OPTIONEN</button>
+  </div>
+  <div id="controls"><h2>🕹️ STEUERUNG</h2><p>SPACE / TAP</p><button onclick="backToMenu()">🔙 ZURÜCK</button></div>
+  <div id="options">
+    <h2>⚙️ OPTIONEN</h2>
+    <label id="volumeLabel">Lautstärke: <input type="range" min="0" max="1" step="0.01" value="0.5" id="volumeSlider"></label><br><br>
+    <button onclick="resetHighscore()">⛔ HIGHSCORE LÖSCHEN</button><br><br>
+    <button onclick="backToMenu()">🔙 ZURÜCK</button>
+  </div>
+  <div id="gameover">
+    <h1>💀 GAME OVER</h1>
+    <p id="scoreDisplay" style="margin-top: 60px;"></p>
+    <button onclick="prepareGame()">🔁 NOCHMAL</button>
+    <button onclick="showOptions()">⚙️ OPTIONEN</button>
+    <button onclick="backToMenu()">🚪 AUFGEBEN</button>
+  </div>
+  <div id="spruch"></div>
+  <div id="wrapper"><canvas id="game" width="1024" height="576" tabindex="0"></canvas></div>
+  <div id="rotateMsg">🔄 Bitte Gerät drehen</div>
+  <audio id="bgmusic" src="bgmusic.mp3" loop></audio>
+  <audio id="darkmusic" src="darktheme.mp3" loop></audio>
+  <audio id="gameovermusic" src="gameover.mp3" loop></audio>
+  <script>
+const canvas = document.getElementById("game");
+const ctx = canvas.getContext("2d");
+const player = { x: 100, y: 0, width: 32, height: 32, velY: 0, onGround: false };
+const gravity = 0.6, jumpForce = -16;
+let scrollX = 0, speed = 3, speedTimer = 0, score = 0;
+let platforms = [], gameReady = false, isGameRunning = false;
+const maxJumpHeight = Math.pow(Math.abs(jumpForce), 2) / (2 * gravity);
+let darkMusicStarted = false;
+let highscore = parseInt(localStorage.getItem("highscore") || "0");
+let wasInGameOverScreen = false;
+let deathMode = false;
+let deathMarkers = [];
+const deathModeBtn = document.getElementById("deathModeBtn");
+
+function fitScreen() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+}
+
+function goFullscreen() {
+  const el = document.documentElement;
+  const req = el.requestFullscreen || el.webkitRequestFullscreen || el.mozRequestFullScreen || el.msRequestFullscreen;
+  if (req) {
+    req.call(el).catch(() => {});
+  }
+  canvas.focus();
+}
+
+window.addEventListener("resize", fitScreen);
+window.addEventListener("orientationchange", () => { fitScreen(); checkOrientation(); });
+document.addEventListener("fullscreenchange", fitScreen);
+fitScreen();
+
+const music = document.getElementById("bgmusic");
+const darkMusic = document.getElementById("darkmusic");
+const gameoverMusic = document.getElementById("gameovermusic");
+let resumeAudios = [];
+const sayings = [
+  "🌈 Beim nächsten Mal klappt’s bestimmt!",
+  "💪 Aufstehen, Krone richten, weiterhüpfen!",
+  "🎮 Das war nur der Probelauf.",
+  "🌟 Du bist der Held unserer Herzen!",
+  "☕ Eine Pause und dann: Comeback!"
+];
+
+const menu = document.getElementById("menu");
+const options = document.getElementById("options");
+const controls = document.getElementById("controls");
+const gameover = document.getElementById("gameover");
+const spruchBox = document.getElementById("spruch");
+const scoreDisplay = document.getElementById("scoreDisplay");
+
+document.getElementById("volumeSlider").addEventListener("input", e => {
+  const vol = parseFloat(e.target.value);
+  [music, darkMusic, gameoverMusic].forEach(a => a.volume = vol);
+});
+
+function pauseAllAudio() {
+  [music, darkMusic, gameoverMusic].forEach(a => {
+    if (!a.paused) {
+      a.pause();
+      resumeAudios.push(a);
+    }
+  });
+}
+
+function resumePausedAudio() {
+  resumeAudios.forEach(a => a.play().catch(() => {}));
+  resumeAudios = [];
+}
+
+function handleVisibilityChange() {
+  if (document.hidden) {
+    pauseAllAudio();
+  } else {
+    resumePausedAudio();
+  }
+}
+
+document.addEventListener("visibilitychange", handleVisibilityChange);
+window.addEventListener("pagehide", pauseAllAudio);
+window.addEventListener("pageshow", resumePausedAudio);
+
+function resetHighscore() {
+  highscore = 0;
+  localStorage.setItem("highscore", "0");
+}
+
+function toggleDeathMode() {
+  deathMode = !deathMode;
+  deathModeBtn.textContent = `DEATH MODE: ${deathMode ? 'AN' : 'AUS'}`;
+}
+
+function easeInOutQuad(x) {
+  return x < 0.5 ? 2 * x * x : 1 - Math.pow(-2 * x + 2, 2) / 2;
+}
+
+function lerp(a, b, t) { return a + (b - a) * t; }
+
+function lerpColor(c1, c2, t) {
+  const r = Math.round(lerp(c1[0], c2[0], t));
+  const g = Math.round(lerp(c1[1], c2[1], t));
+  const b = Math.round(lerp(c1[2], c2[2], t));
+  return `rgb(${r},${g},${b})`;
+}
+
+function blend3(c1, c2, c3, t) {
+  return t < 0.5
+    ? lerpColor(c1, c2, t * 2)
+    : lerpColor(c2, c3, (t - 0.5) * 2);
+}
+
+function lighten(color, t) {
+  return [
+    lerp(color[0], 255, t),
+    lerp(color[1], 255, t),
+    lerp(color[2], 255, t)
+  ];
+}
+
+function showMenu() {
+  [menu].forEach(el => el.style.display = "block");
+  [options, controls, gameover, spruchBox].forEach(el => el.style.display = "none");
+  isGameRunning = false;
+  deathModeBtn.textContent = `DEATH MODE: ${deathMode ? 'AN' : 'AUS'}`;
+}
+
+function backToMenu() {
+  [options, controls, gameover, spruchBox].forEach(el => el.style.display = "none");
+  menu.style.display = "block";
+}
+
+function showOptions() {
+  [menu, controls, gameover].forEach(el => el.style.display = "none");
+  options.style.display = "block";
+}
+
+function showControls() {
+  [menu, options, gameover].forEach(el => el.style.display = "none");
+  controls.style.display = "block";
+}
+
+function maxJumpDistance(currentSpeed) {
+  const maxJumpTime = (Math.abs(jumpForce) * 2) / gravity;
+  return currentSpeed * maxJumpTime;
+}
+
+function createPlatform() {
+  const baseY = canvas.height - 80;
+  const last = platforms[platforms.length - 1];
+  const maxGap = Math.max(100, maxJumpDistance(speed) * 0.9);
+  const minGap = maxGap * 0.4;
+  const gap = Math.random() * (maxGap - minGap) + minGap;
+  const maxHeightChange = Math.min(150, maxJumpHeight - 20);
+  let y = last.y + Math.random() * maxHeightChange * 2 - maxHeightChange;
+  y = Math.max(270, Math.min(baseY, y));
+  const width = Math.random() * 60 + 80;
+  const x = last.x + last.width + gap;
+  platforms.push({ x, y, width, height: 16 });
+}
+
+function prepareGame() {
+  goFullscreen();
+  fitScreen();
+  [gameoverMusic, darkMusic, music].forEach(a => { a.pause(); a.currentTime = 0; });
+  darkMusicStarted = false;
+  wasInGameOverScreen = false;
+  [menu, options, controls, gameover, spruchBox].forEach(el => el.style.display = "none");
+  scrollX = 0; speed = 3; speedTimer = 0; platforms = []; score = 0; deathMarkers = [];
+  const baseY = canvas.height - 80;
+  const clampY = y => Math.max(270, Math.min(baseY, y));
+
+  let x = 0, y = baseY;
+  platforms.push({ x, y, width: 120, height: 16 });
+
+  x += 160;
+  y = clampY(y + (Math.random() * 60 - 30));
+  platforms.push({ x, y, width: 110, height: 16 });
+
+  x += 180;
+  y = clampY(y + (Math.random() * 80 - 40));
+  platforms.push({ x, y, width: 110, height: 16 });
+
+  x += 200;
+  y = clampY(y + (Math.random() * 80 - 40));
+  platforms.push({ x, y, width: 100, height: 16 });
+
+  for (let i = platforms.length; i < 15; i++) {
+    createPlatform();
+  }
+
+  const firstPlatform = platforms[0];
+  player.x = firstPlatform.x + firstPlatform.width / 2 - player.width / 2;
+  player.y = firstPlatform.y - player.height;
+
+  scrollX = player.x - canvas.width * 0.3;
+  player.velY = 0;
+  player.onGround = true;
+  gameReady = true;
+  isGameRunning = false;
+  draw();
+  lastTime = performance.now();
+  requestAnimationFrame(gameLoop);
+}
+
+function startGame(withJump = false) {
+  goFullscreen();
+  fitScreen();
+  isGameRunning = true;
+  music.volume = 0.5;
+  [music, darkMusic].forEach(a => { a.pause(); a.currentTime = 0; });
+  music.play().catch(() => {});
+  if (withJump && player.onGround) {
+    player.velY = jumpForce;
+    player.onGround = false;
+  }
+}
+
+document.addEventListener("keydown", e => {
+  if (e.code === "Space") {
+    if (!isGameRunning && (wasInGameOverScreen || gameover.style.display === "block")) {
+      wasInGameOverScreen = false;
+      prepareGame();
+      return;
+    }
+    if (gameReady) {
+      startGame(true);
+      gameReady = false;
+    } else if (player.onGround) {
+      player.velY = jumpForce;
+      player.onGround = false;
+    }
+  }
+});
+
+canvas.addEventListener("touchstart", e => {
+  e.preventDefault();
+  if (gameReady) {
+    startGame(true);
+    gameReady = false;
+  } else if (player.onGround) {
+    player.velY = jumpForce;
+    player.onGround = false;
+  }
+}, { passive: false });
+
+function checkOrientation() {
+  if (window.matchMedia("(orientation: portrait)").matches) {
+    isGameRunning = false;
+    pauseAllAudio();
+  } else if (!document.hidden) {
+    resumePausedAudio();
+  }
+}
+checkOrientation();
+
+let lastTime = 0;
+function gameLoop(timestamp) {
+  const delta = (timestamp - lastTime) / 16.6667;
+  lastTime = timestamp;
+  update(delta);
+  draw();
+  requestAnimationFrame(gameLoop);
+}
+
+function update(delta) {
+  if (!isGameRunning) return;
+  speedTimer += delta;
+  score = Math.floor(speedTimer / 10);
+
+  if (score >= 300 && !darkMusicStarted) {
+    darkMusicStarted = true;
+    darkMusic.volume = 0;
+    darkMusic.play().catch(() => {});
+  }
+
+  if (darkMusicStarted) {
+    music.volume = Math.max(0, music.volume - 0.0007 * delta);
+    darkMusic.volume = Math.min(0.5, darkMusic.volume + 0.0007 * delta);
+  }
+
+  if (Math.floor(speedTimer / 600) > Math.floor((speedTimer - delta) / 600) && speed < 6) {
+    speed += 0.25;
+  }
+
+  player.velY += gravity * delta;
+  player.y += player.velY * delta;
+  if (player.y < 20 && player.velY < 0) player.velY *= 0.5;
+  player.x += speed * delta;
+  scrollX = player.x - canvas.width * 0.3;
+
+  if (platforms[0].x + platforms[0].width < scrollX - 100) {
+    platforms.shift();
+    createPlatform();
+  }
+
+  player.onGround = false;
+  for (let p of platforms) {
+    if (player.x < p.x + p.width && player.x + player.width > p.x &&
+        player.y + player.height < p.y + 10 &&
+        player.y + player.height + player.velY * delta >= p.y) {
+      player.y = p.y - player.height;
+      player.velY = 0;
+      player.onGround = true;
+    }
+  }
+
+  if (player.y > canvas.height) {
+    if (deathMode) {
+      deathMarkers.push({ x: player.x, y: canvas.height - 10 });
+      const next = platforms.find(p => p.x + p.width > player.x) || platforms[platforms.length - 1];
+      player.x = next.x + next.width / 2 - player.width / 2;
+      player.y = next.y - player.height;
+      player.velY = 0;
+      scrollX = player.x - canvas.width * 0.3;
+    } else {
+      isGameRunning = false;
+      wasInGameOverScreen = true;
+      if (score > highscore) {
+        highscore = score;
+        localStorage.setItem("highscore", highscore);
+      }
+      scoreDisplay.innerHTML = `Dein Score: ${score}<br><br>Highscore: ${highscore}`;
+      spruchBox.textContent = sayings[Math.floor(Math.random() * sayings.length)];
+      spruchBox.style.display = "block";
+      gameover.style.display = "block";
+      [music, darkMusic].forEach(a => { a.pause(); a.currentTime = 0; });
+      gameoverMusic.play().catch(() => {});
+    }
+  }
+}
+
+function draw() {
+  const corruption = Math.min(1, score / 500);
+  const smooth = easeInOutQuad(corruption);
+  const skyTop = lerpColor([94, 194, 240], [194, 94, 40], smooth);
+  const skyBottom = lerpColor([204, 238, 255], [134, 38, 0], smooth);
+  const sky = ctx.createLinearGradient(0, 0, 0, canvas.height);
+  sky.addColorStop(0, skyTop);
+  sky.addColorStop(1, skyBottom);
+  ctx.fillStyle = sky;
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+  for (let p of platforms) {
+    const r = lerp(76, 176, smooth);
+    const g = lerp(175, 25, smooth);
+    const b = lerp(80, 0, smooth);
+    const base = [r, g, b];
+    const highlight = lighten(base, 0.25);
+    const grad = ctx.createLinearGradient(0, p.y, 0, p.y + 8);
+    grad.addColorStop(0, `rgb(${Math.round(highlight[0])},${Math.round(highlight[1])},${Math.round(highlight[2])})`);
+    grad.addColorStop(1, `rgb(${Math.round(r)},${Math.round(g)},${Math.round(b)})`);
+    ctx.fillStyle = grad;
+    ctx.fillRect(p.x - scrollX, p.y, p.width, 8);
+    ctx.fillStyle = `rgba(${Math.round(r - 50)},0,0,0.6)`;
+    ctx.fillRect(p.x - scrollX, p.y + 8, p.width, 8);
+  }
+
+  for (let m of deathMarkers) {
+    ctx.fillStyle = 'red';
+    ctx.beginPath();
+    ctx.arc(m.x - scrollX, m.y, 5, 0, Math.PI * 2);
+    ctx.fill();
+  }
+
+  const px = player.x - scrollX, py = player.y;
+  const bodyColor = blend3([255,80,80],[136,136,136],[85,107,47], smooth);
+  const eyeOuter = lerpColor([0,0,0],[255,0,0], Math.max(0,(smooth-0.3)/0.7));
+  const eyeInner = lerpColor([255,255,255],[255,160,160], Math.max(0,(smooth-0.3)/0.7));
+  const mouthColor = lerpColor([0,0,0],[170,0,0], Math.max(0,(smooth-0.5)/0.5));
+  const armColor = lerpColor([204,0,0],[102,0,0], Math.max(0,(smooth-0.5)/0.5));
+  
+  ctx.fillStyle = bodyColor;
+  ctx.fillRect(px, py, player.width, player.height);
+
+  ctx.fillStyle = eyeOuter;
+  ctx.fillRect(px + 6, py + 4, 6, 6);
+  ctx.fillRect(px + 20, py + 4, 6, 6);
+
+  ctx.fillStyle = eyeInner;
+  ctx.fillRect(px + 8, py + 6, 2, 2);
+  ctx.fillRect(px + 22, py + 6, 2, 2);
+
+  ctx.fillStyle = mouthColor;
+  ctx.fillRect(px + 10, py + 12, 12, 4 + smooth * 2);
+  if (smooth > 0.5) {
+    ctx.fillStyle = `rgba(255,255,255,${(smooth-0.5)*2})`;
+    ctx.fillRect(px + 11, py + 12, 2, 4);
+    ctx.fillRect(px + 14, py + 12, 2, 4);
+    ctx.fillRect(px + 17, py + 12, 2, 4);
+  }
+
+  ctx.fillStyle = armColor;
+  ctx.fillRect(px - 4, py + 12, 4, 10);
+  ctx.fillRect(px + player.width, py + 12, 4, 10);
+  ctx.fillRect(px + 2, py + player.height - 4, 8, 4);
+  ctx.fillRect(px + 22, py + player.height - 4, 8, 4);
+
+  if (smooth > 0.8) {
+    ctx.save();
+    ctx.globalAlpha = (smooth - 0.8) / 0.2;
+    ctx.fillStyle = "#222";
+    ctx.fillRect(px + 5, py + 20, 3, 3);
+    ctx.fillRect(px + 18, py + 24, 4, 2);
+    ctx.fillRect(px + 13, py + 6, 2, 2);
+    ctx.restore();
+  }
+
+  // Score oben rechts, leicht nach unten versetzt
+  const scoreX = canvas.width - 10;
+  const scoreY = 50;
+  ctx.font = "16px 'Press Start 2P'";
+  ctx.textAlign = "right";
+  ctx.textBaseline = "top";
+  ctx.fillStyle = "black";
+  ctx.fillText("Score: " + score, scoreX + 1, scoreY + 1);
+  ctx.fillStyle = "white";
+  ctx.fillText("Score: " + score, scoreX, scoreY);
+}
+
+showMenu();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- copy existing index.html to new deathmode.html
- add button to toggle death mode
- implement death mode logic (teleport to next platform instead of game over)
- mark death locations with red dots

## Testing
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_e_68827571b8a0832aafda48ec3256f8b5