### PR TITLE
Pause bgmusic after fade

### DIFF
--- a/index.html
+++ b/index.html
@@ -567,7 +567,10 @@ function update(delta) {
   if (darkMusicStarted) {
     music.volume = Math.max(0, music.volume - 0.001 * delta);
     darkMusic.volume = Math.min(1, darkMusic.volume + 0.001 * delta);
-    if (music.volume === 0) music.pause();
+    if (music.volume <= 0.001 && darkMusic.volume >= 1) {
+      music.volume = 0;
+      music.pause();
+    }
   }
 
   if (Math.floor(speedTimer / 600) > Math.floor((speedTimer - delta) / 600) && speed < 6) {


### PR DESCRIPTION
## Summary
- ensure the regular bgmusic stops after dark theme fades in

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6882a812ca90832aab03a5cf7e472406