### PR TITLE
Fix audio pausing and improve input handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -210,7 +210,15 @@ function goFullscreen() {
 
 window.addEventListener("resize", fitScreen);
 window.addEventListener("orientationchange", () => { fitScreen(); checkOrientation(); });
-document.addEventListener("fullscreenchange", fitScreen);
+document.addEventListener("fullscreenchange", () => {
+  fitScreen();
+  if (!document.fullscreenElement) {
+    pauseAllAudio();
+  } else if (!document.hidden) {
+    resumePausedAudio();
+    canvas.focus();
+  }
+});
 fitScreen();
 
 const music = document.getElementById("bgmusic");
@@ -508,6 +516,7 @@ function startGame(withJump = false) {
 
 document.addEventListener("keydown", e => {
   if (e.code === "Space") {
+    e.preventDefault();
     if (!isGameRunning && (wasInGameOverScreen || gameover.style.display === "block")) {
       wasInGameOverScreen = false;
       prepareGame();


### PR DESCRIPTION
## Summary
- pause all music when leaving fullscreen and resume when returning
- prevent page scrolling with space key to keep keyboard controls working

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6882aa1475d4832aac08e35a8af1edd4