### PR TITLE
Implement visual effects and parallax background

### DIFF
--- a/index.html
+++ b/index.html
@@ -99,6 +99,27 @@
       transform: translateY(-2px);
       box-shadow: 0 6px 0 #007a66, 0 6px 12px rgba(0,0,0,0.6);
     }
+    .dark-flicker {
+      animation: flicker 2s infinite;
+    }
+    @keyframes flicker {
+      0%, 18%, 22%, 25%, 53%, 57%, 100% {
+        opacity: 1;
+      }
+      20%, 24%, 55% {
+        opacity: 0.4;
+      }
+    }
+    .shake {
+      animation: shake 0.5s infinite;
+    }
+    @keyframes shake {
+      0%, 100% { transform: translate(-50%, -50%); }
+      20% { transform: translate(calc(-50% - 2px), calc(-50% + 2px)); }
+      40% { transform: translate(calc(-50% + 2px), calc(-50% - 2px)); }
+      60% { transform: translate(calc(-50% + 1px), calc(-50% + 3px)); }
+      80% { transform: translate(calc(-50% - 1px), calc(-50% - 1px)); }
+    }
     #gameover button {
       border-color: #ff0033;
       color: #000;
@@ -193,10 +214,25 @@ let wasInGameOverScreen = false;
 let devUnlocked = false;
 let devMode = false;
 let deathDots = [];
+let clouds = [], mountains = [], trees = [];
+let lightningTimer = 0;
+let scoreDrips = [];
 
 function fitScreen() {
   canvas.width = window.innerWidth;
   canvas.height = window.innerHeight;
+}
+
+function initBackground() {
+  clouds = [];
+  mountains = [];
+  trees = [];
+  const total = Math.ceil(canvas.width / 200) + 5;
+  for (let i = 0; i < total; i++) {
+    clouds.push({ x: i * 200, y: 80 + Math.random() * 40 });
+    mountains.push({ x: i * 180, y: canvas.height - 180 - Math.random() * 40 });
+    trees.push({ x: i * 160, y: canvas.height - 120 - Math.random() * 20 });
+  }
 }
 
 function goFullscreen() {
@@ -407,12 +443,16 @@ function showMenu() {
   [options, controls, gameover, spruchBox].forEach(el => el.style.display = "none");
   isGameRunning = false;
   if (devModal) devModal.style.display = "none";
+  document.body.classList.remove('dark-flicker');
+  menu.classList.remove('shake');
 }
 
 function backToMenu() {
   [options, controls, gameover, spruchBox].forEach(el => el.style.display = "none");
   menu.style.display = "block";
   if (devModal) devModal.style.display = "none";
+  document.body.classList.remove('dark-flicker');
+  menu.classList.remove('shake');
 }
 
 function showOptions() {
@@ -464,7 +504,8 @@ function prepareGame() {
   darkMusicStarted = false;
   wasInGameOverScreen = false;
   [menu, options, controls, gameover, spruchBox].forEach(el => el.style.display = "none");
-  scrollX = 0; speed = 3; speedTimer = 0; platforms = []; score = 0;
+  scrollX = 0; speed = 3; speedTimer = 0; platforms = []; score = 0; lightningTimer = 0;
+  initBackground();
   const baseY = canvas.height - 80;
   const clampY = y => Math.max(270, Math.min(baseY, y));
 
@@ -571,6 +612,8 @@ function update(delta) {
     darkMusicStarted = true;
     darkMusic.volume = 0;
     darkMusic.play().catch(() => {});
+    document.body.classList.add('dark-flicker');
+    menu.classList.add('shake');
   }
 
   if (darkMusicStarted) {
@@ -579,6 +622,16 @@ function update(delta) {
     if (music.volume <= 0.001 && darkMusic.volume >= 1) {
       music.volume = 0;
       music.pause();
+    }
+    if (score > 600 && Math.random() < 0.01 && lightningTimer <= 0) {
+      lightningTimer = 6;
+      [music, darkMusic].forEach(a => a.playbackRate = 1.3);
+    }
+    if (lightningTimer > 0) {
+      lightningTimer -= delta;
+      if (lightningTimer <= 0) {
+        [music, darkMusic].forEach(a => a.playbackRate = 1);
+      }
     }
   }
 
@@ -640,6 +693,39 @@ function draw() {
   ctx.fillStyle = sky;
   ctx.fillRect(0, 0, canvas.width, canvas.height);
 
+  clouds.forEach(cl => {
+    let x = cl.x - scrollX * 0.2;
+    if (x + 60 < 0) cl.x += clouds.length * 200;
+    ctx.fillStyle = 'rgba(255,255,255,0.8)';
+    ctx.fillRect(x, cl.y, 60, 20);
+  });
+
+  mountains.forEach(m => {
+    let x = m.x - scrollX * 0.4;
+    if (x + 120 < 0) m.x += mountains.length * 180;
+    ctx.fillStyle = '#334';
+    ctx.beginPath();
+    ctx.moveTo(x, m.y + 120);
+    ctx.lineTo(x + 60, m.y);
+    ctx.lineTo(x + 120, m.y + 120);
+    ctx.closePath();
+    ctx.fill();
+  });
+
+  trees.forEach(t => {
+    let x = t.x - scrollX * 0.7;
+    if (x + 20 < 0) t.x += trees.length * 160;
+    ctx.fillStyle = '#262';
+    ctx.fillRect(x + 6, t.y + 20, 8, 40);
+    ctx.fillStyle = '#3b3';
+    ctx.beginPath();
+    ctx.moveTo(x, t.y + 20);
+    ctx.lineTo(x + 20, t.y + 20);
+    ctx.lineTo(x + 10, t.y);
+    ctx.closePath();
+    ctx.fill();
+  });
+
   for (let p of platforms) {
     const gr = lerp(95, 70, smooth);
     const gg = lerp(166, 70, smooth);
@@ -676,19 +762,25 @@ function draw() {
   }
 
   const px = player.x - scrollX, py = player.y;
-  const bodyBase = [
-    lerp(200, 20, smooth),
-    lerp(0, 60, smooth),
-    lerp(0, 20, smooth)
-  ];
-  const eyeOuter = lerpColor([0,0,0],[255,0,0], Math.max(0,(smooth-0.3)/0.7));
-  const eyeInner = lerpColor([255,255,255],[255,160,160], Math.max(0,(smooth-0.3)/0.7));
-  const mouthColor = lerpColor([0,0,0],[170,0,0], Math.max(0,(smooth-0.5)/0.5));
-  const armBase = [
-    lerp(200, 20, smooth),
-    lerp(0, 60, smooth),
-    lerp(0, 20, smooth)
-  ];
+  const stage = score >= 600 ? 3 : score >= 400 ? 2 : score >= 200 ? 1 : 0;
+  let bodyBase;
+  if (stage === 0) bodyBase = [200,0,0];
+  else if (stage === 1) bodyBase = [120,40,40];
+  else if (stage === 2) bodyBase = [220,220,220];
+  else bodyBase = [80,0,0];
+  let eyeOuter = lerpColor([0,0,0],[255,0,0], Math.max(0,(smooth-0.3)/0.7));
+  let eyeInner = lerpColor([255,255,255],[255,160,160], Math.max(0,(smooth-0.3)/0.7));
+  let mouthColor = lerpColor([0,0,0],[170,0,0], Math.max(0,(smooth-0.5)/0.5));
+  if (stage === 2) {
+    eyeOuter = '#000';
+    eyeInner = '#fff';
+    mouthColor = '#000';
+  } else if (stage === 3) {
+    eyeOuter = '#ff0000';
+    eyeInner = '#ffe0e0';
+    mouthColor = '#ff0000';
+  }
+  const armBase = bodyBase;
 
   const topColor = rgbString(shade(bodyBase, 0.25));
   const sideColor = rgbString(shade(bodyBase, -0.25));
@@ -730,7 +822,10 @@ function draw() {
   ctx.fillRect(px + 22, py + 6, 2, 2);
 
   ctx.fillStyle = mouthColor;
-  ctx.fillRect(px + 10, py + 12, 12, 4 + smooth * 2);
+  if (stage === 2)
+    ctx.fillRect(px + 10, py + 14, 12, 2);
+  else
+    ctx.fillRect(px + 10, py + 12, 12, 4 + smooth * 2);
 
   const armFront = rgbString(lighten(armBase, 0.2));
   const armSide = rgbString(shade(armBase, -0.25));
@@ -761,6 +856,25 @@ function draw() {
   ctx.fillText("Score: " + score, scoreX + 1, scoreY + 1);
   ctx.fillStyle = "white";
   ctx.fillText("Score: " + score, scoreX, scoreY);
+
+  if (smooth > 0.6 && Math.random() < 0.05) {
+    const w = ctx.measureText("Score: " + score).width;
+    scoreDrips.push({ x: scoreX - w + Math.random() * w * 2, y: scoreY + 16, vy: 0 });
+  }
+  ctx.fillStyle = "red";
+  scoreDrips = scoreDrips.filter(d => d.y < canvas.height);
+  for (let d of scoreDrips) {
+    d.vy += 0.3;
+    d.y += d.vy;
+    ctx.beginPath();
+    ctx.arc(d.x, d.y, 2, 0, Math.PI * 2);
+    ctx.fill();
+  }
+
+  if (lightningTimer > 0) {
+    ctx.fillStyle = 'rgba(255,255,255,' + (lightningTimer / 6).toFixed(2) + ')';
+    ctx.fillRect(0,0,canvas.width,canvas.height);
+  }
 }
 
 showMenu();


### PR DESCRIPTION
## Summary
- add CSS shake and flicker animations for dark mode
- create parallax background layers for clouds, mountains and trees
- reset and initialize background on game start
- implement multiple player transformation stages
- draw blood drips from the score and random lightning flashes later in the game
- flash screen and speed up music on lightning

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6882adc44234832ab68e61d5ecefaf04