### PR TITLE
Improve late game visuals

### DIFF
--- a/index.html
+++ b/index.html
@@ -214,6 +214,7 @@ let wasInGameOverScreen = false;
 let devUnlocked = false;
 let devMode = false;
 let deathDots = [];
+// background elements
 let clouds = [], mountains = [], trees = [];
 let lightningTimer = 0;
 let scoreDrips = [];
@@ -227,12 +228,12 @@ function initBackground() {
   clouds = [];
   mountains = [];
   trees = [];
-  const total = Math.ceil(canvas.width / 200) + 5;
+  const total = Math.ceil(canvas.width / 300) + 2;
   for (let i = 0; i < total; i++) {
-    clouds.push({ x: i * 200, y: 80 + Math.random() * 40 });
+    clouds.push({ x: i * 300, y: 80 + Math.random() * 40 });
     mountains.push({ x: i * 180, y: canvas.height - 180 - Math.random() * 40 });
-    trees.push({ x: i * 160, y: canvas.height - 120 - Math.random() * 20 });
   }
+  // do not spawn trees
 }
 
 function goFullscreen() {
@@ -616,6 +617,11 @@ function update(delta) {
     menu.classList.add('shake');
   }
 
+  if (score >= 600) {
+    document.body.classList.remove('dark-flicker');
+    menu.classList.remove('shake');
+  }
+
   if (darkMusicStarted) {
     music.volume = Math.max(0, music.volume - 0.001 * delta);
     darkMusic.volume = Math.min(1, darkMusic.volume + 0.001 * delta);
@@ -623,15 +629,11 @@ function update(delta) {
       music.volume = 0;
       music.pause();
     }
-    if (score > 600 && Math.random() < 0.01 && lightningTimer <= 0) {
+    if (score > 600 && Math.random() < 0.005 && lightningTimer <= 0) {
       lightningTimer = 6;
-      [music, darkMusic].forEach(a => a.playbackRate = 1.3);
     }
     if (lightningTimer > 0) {
       lightningTimer -= delta;
-      if (lightningTimer <= 0) {
-        [music, darkMusic].forEach(a => a.playbackRate = 1);
-      }
     }
   }
 
@@ -695,9 +697,13 @@ function draw() {
 
   clouds.forEach(cl => {
     let x = cl.x - scrollX * 0.2;
-    if (x + 60 < 0) cl.x += clouds.length * 200;
+    if (x + 60 < 0) cl.x += clouds.length * 300;
     ctx.fillStyle = 'rgba(255,255,255,0.8)';
-    ctx.fillRect(x, cl.y, 60, 20);
+    ctx.beginPath();
+    ctx.arc(x + 15, cl.y + 10, 10, 0, Math.PI * 2);
+    ctx.arc(x + 30, cl.y + 5, 15, 0, Math.PI * 2);
+    ctx.arc(x + 45, cl.y + 10, 10, 0, Math.PI * 2);
+    ctx.fill();
   });
 
   mountains.forEach(m => {
@@ -712,19 +718,7 @@ function draw() {
     ctx.fill();
   });
 
-  trees.forEach(t => {
-    let x = t.x - scrollX * 0.7;
-    if (x + 20 < 0) t.x += trees.length * 160;
-    ctx.fillStyle = '#262';
-    ctx.fillRect(x + 6, t.y + 20, 8, 40);
-    ctx.fillStyle = '#3b3';
-    ctx.beginPath();
-    ctx.moveTo(x, t.y + 20);
-    ctx.lineTo(x + 20, t.y + 20);
-    ctx.lineTo(x + 10, t.y);
-    ctx.closePath();
-    ctx.fill();
-  });
+  // trees were removed for a cleaner background
 
   for (let p of platforms) {
     const gr = lerp(95, 70, smooth);
@@ -872,7 +866,7 @@ function draw() {
   }
 
   if (lightningTimer > 0) {
-    ctx.fillStyle = 'rgba(255,255,255,' + (lightningTimer / 6).toFixed(2) + ')';
+    ctx.fillStyle = 'rgba(255,255,255,' + (lightningTimer / 10).toFixed(2) + ')';
     ctx.fillRect(0,0,canvas.width,canvas.height);
   }
 }


### PR DESCRIPTION
## Summary
- tweak background initialization so fewer clouds appear and trees are removed
- draw clouds using circles instead of rectangles
- remove tree rendering
- tone down dark stage effects after score 600
- lessen lightning screen flash

## Testing
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_e_6882b06c66e0832a8dee1c3ca9edd812