### PR TITLE
Fix sound for iOS homescreen

### DIFF
--- a/index.html
+++ b/index.html
@@ -426,6 +426,11 @@ function unlockAudio() {
   });
   audioUnlocked = true;
 }
+// Ensure audio can be unlocked on iOS when launched from the home screen
+// by listening for the first user interaction anywhere on the page
+document.addEventListener('touchstart', unlockAudio, { once: true });
+document.addEventListener('mousedown', unlockAudio, { once: true });
+document.addEventListener('keydown', unlockAudio, { once: true });
 
 function handleVisibilityChange() {
   if (document.hidden) {


### PR DESCRIPTION
## Summary
- trigger audio unlock on first interaction so PWA sound works on iOS

## Testing
- `apt-get update`
- `apt-get install -y w3m`


------
https://chatgpt.com/codex/tasks/task_e_6882c38d7d88832aaf1c450d9d1bc89a