### PR TITLE
Enable music only on game start

### DIFF
--- a/index.html
+++ b/index.html
@@ -426,11 +426,6 @@ function unlockAudio() {
   });
   audioUnlocked = true;
 }
-// Ensure audio can be unlocked on iOS when launched from the home screen
-// by listening for the first user interaction anywhere on the page
-document.addEventListener('touchstart', unlockAudio, { once: true });
-document.addEventListener('mousedown', unlockAudio, { once: true });
-document.addEventListener('keydown', unlockAudio, { once: true });
 
 function handleVisibilityChange() {
   if (document.hidden) {
@@ -640,7 +635,6 @@ function respawnPlayer() {
 
 function prepareGame() {
   goFullscreen();
-  unlockAudio();
   fitScreen();
   [gameoverMusic, darkMusic, music].forEach(a => { a.pause(); a.currentTime = 0; });
   darkMusicStarted = false;


### PR DESCRIPTION
## Summary
- remove global audio unlock listeners
- only unlock music when starting the game

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6882c602a714832ab095a176c7e52019