### PR TITLE
Unlock audio on page load

### DIFF
--- a/index.html
+++ b/index.html
@@ -421,11 +421,14 @@ function resumePausedAudio() {
 function unlockAudio() {
   if (audioUnlocked) return;
   [music, darkMusic, gameoverMusic].forEach(a => {
-    const p = a.play();
-    if (p) p.then(() => { a.pause(); a.currentTime = 0; });
+    a.play()
+      .then(() => { a.pause(); a.currentTime = 0; })
+      .catch(() => {});
   });
   audioUnlocked = true;
 }
+
+window.addEventListener("load", unlockAudio);
 
 function handleVisibilityChange() {
   if (document.hidden) {


### PR DESCRIPTION
## Summary
- improve `unlockAudio()` to handle autoplay restrictions gracefully
- call `unlockAudio()` once the page has loaded so audio is ready before the game starts

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6882c7f32c50832aaa1bfec6f8e668a5