### PR TITLE
Fix audio unlocking interfering with background music

### DIFF
--- a/index.html
+++ b/index.html
@@ -418,13 +418,15 @@ function resumePausedAudio() {
   resumeAudios = [];
 }
 
-function unlockAudio() {
+async function unlockAudio() {
   if (audioUnlocked) return;
-  [music, darkMusic, gameoverMusic].forEach(a => {
-    a.play()
-      .then(() => { a.pause(); a.currentTime = 0; })
-      .catch(() => {});
-  });
+  for (const a of [music, darkMusic, gameoverMusic]) {
+    try {
+      await a.play();
+      a.pause();
+      a.currentTime = 0;
+    } catch (e) {}
+  }
   audioUnlocked = true;
 }
 
@@ -682,9 +684,9 @@ function prepareGame() {
   requestAnimationFrame(gameLoop);
 }
 
-function startGame(withJump = false) {
+async function startGame(withJump = false) {
   goFullscreen();
-  unlockAudio();
+  await unlockAudio();
   fitScreen();
   isGameRunning = true;
   music.volume = 0.5;


### PR DESCRIPTION
## Summary
- make `unlockAudio` asynchronous and pause audios only after they have started
- wait for audio unlocking before starting the game so music isn't immediately paused

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_6882c9ce6834832a9978561ad6907c05